### PR TITLE
fix: execute release nag only if preconditions are met

### DIFF
--- a/.github/workflows/tagpush.yml
+++ b/.github/workflows/tagpush.yml
@@ -3,49 +3,21 @@ name: Manual Release Nag
 on:
   workflow_call:
 
-env:
-  ISSUE_TITLE: "manual release created (%tagname%)"
-  ISSUE_ASSIGNEE: "%pusher%"
-  ISSUE_BODY: |
-    @{{ env.PUSHER }} just pushed a release tag: {{ env.TAGNAME }}.
-    Please manually verify validity (using [\`gorelease\`](https://pkg.go.dev/golang.org/x/exp/cmd/gorelease)), and update \`version.json\` to reflect the manually released version, if necessary.
-    In the future, please use the [automated process](https://github.com/ipdxco/unified-github-workflows/blob/master/VERSIONING.md).
-
 jobs:
-  unit:
+  nag:
+    if: startsWith(github.ref, 'refs/tags') && github.event.pusher.name != 'web3-bot'
     runs-on: ubuntu-latest
     name: All
-    env:
-      TAGNAME: ""
     steps:
-      - uses: actions/checkout@v4
-      - run: cat "$GITHUB_EVENT_PATH" | jq -M .
-      - name: extract tag name
-        run: |
-          tagname=$(echo "$GITHUB_REF" | sed "s/refs\/tags\///")
-          echo $tagname
-          echo "TAGNAME=$tagname" >> $GITHUB_ENV
-      - name: create issue template file
-        if: github.event.pusher.name != 'web3-bot'
-        env:
-          PUSHER: ${{ github.event.pusher.name }}
-        run: |
-          echo "---" >> .github/workflows/tagpush.md
-          echo "title: $ISSUE_TITLE" | sed "s/%tagname%/$TAGNAME/" >> .github/workflows/tagpush.md
-          echo "assignees: $ISSUE_ASSIGNEE" | sed "s/%pusher%/$PUSHER/" >> .github/workflows/tagpush.md
-          echo "---" >> .github/workflows/tagpush.md
-          cat <<EOF >> .github/workflows/tagpush.md
-          $ISSUE_BODY
-          EOF
-      - run: cat .github/workflows/tagpush.md
       - name: create an issue
-        if: github.event.pusher.name != 'web3-bot'
-        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          PUSHER: ${{ github.event.pusher.name }}
-        with:
-          filename: .github/workflows/tagpush.md
-      - name: fail build if push wasn't done by web3-bot
-        if: github.event.pusher.name != 'web3-bot'
-        run: exit 1
+          GITHUB_EVENT_PUSHER_NAME: ${{ github.event.pusher.name }}
+          TITLE: manual release created (${GITHUB_REF#refs/tags/})
+          ASSIGNEE: '@$GITHUB_EVENT_PUSHER_NAME'
+          BODY: |
+            @$GITHUB_EVENT_PUSHER_NAME just pushed a release tag: ${GITHUB_REF#refs/tags/}.
+            Please manually verify validity (using [\`gorelease\`](https://pkg.go.dev/golang.org/x/exp/cmd/gorelease)), and update \`version.json\` to reflect the manually released version, if necessary.
+            In the future, please use the [automated process](https://github.com/ipdxco/unified-github-workflows/blob/master/VERSIONING.md).
+        run: |
+          gh issue create --title="$(echo "$TITLE" | envsubst)" --assignee="$(echo "$ASSIGNEE" | envsubst)" --body="$(echo "$BODY" | envsubst)" --repo="$GITHUB_REPO"


### PR DESCRIPTION
This is a fix for https://ipdx-workspace.slack.com/archives/C03KLC57LKB/p1716533347417879

We should only create an issue when a tag was created manually by non-bot users. In particular, we shouldn't raise an alarm if web3-bot creates a release.