### PR TITLE
Allow Go check and tests to be triggered by `merge_group`

### DIFF
--- a/templates/.github/workflows/go-check.yml
+++ b/templates/.github/workflows/go-check.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: ${{{ .github.protected_branches + [.github.default_branch] | unique }}}
   workflow_dispatch:
+  merge_group:
 
 permissions:
   contents: read

--- a/templates/.github/workflows/go-test.yml
+++ b/templates/.github/workflows/go-test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: ${{{ .github.protected_branches + [.github.default_branch] | unique }}}
   workflow_dispatch:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Allow Go check and test to be triggered via merge queue. This is to accommodate repos that have these workflows marked as mandatory and use merge queue.