### PR TITLE
fix: disable go-cache by default

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -8,6 +8,10 @@ on:
       go-generate-ignore-protoc-version-comments:
         required: false
         type: boolean
+      go-cache:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   unit:
@@ -22,7 +26,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
-          # cache: false
+          cache: false
       - name: Read the Unified GitHub Workflows configuration
         id: config
         uses: ipdxco/unified-github-workflows/.github/actions/read-config@main
@@ -34,7 +38,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version || (fromJSON(steps.go-mod.outputs.json).Go && format('{0}.x', fromJSON(steps.go-mod.outputs.json).Go)) }}
-          cache: false
+          cache: ${{ inputs.go-cache }}
       - name: Run repo-specific setup
         uses: ./.github/actions/go-check-setup
         if: hashFiles('./.github/actions/go-check-setup') != ''

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: '["this", "next"]'
+      go-cache:
+        required: false
+        type: boolean
+        default: false
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -43,7 +47,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
-          # cache: false
+          cache: false
       - name: Read the Unified GitHub Workflows configuration
         id: config
         uses: ipdxco/unified-github-workflows/.github/actions/read-config@main
@@ -85,6 +89,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go.outputs.version }}
+          cache: ${{ inputs.go-cache }}
       - name: Display the Go version and environment
         run: |
           go version

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJSON(steps.go-mod.outputs.json).Go }}.x
+          cache: false
       - id: version
         name: Determine version
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- disable cache in setup-go action by default
 
 ## [1.0.4] - 2024-07-15
 ### Added


### PR DESCRIPTION
Related to https://ipdx-workspace.slack.com/archives/C03KLC57LKB/p1720713111296569

We have observed that using cache (in the default configuration as given by the setup-go action) on many concurrent builds  can lead to extended build times.

I propose that we disable cache in setup-go by default and allow repository maintainers to opt-in to go-cache usage via reusable workflow inputs.

It's worth noting that:
- downloading Go packages directly from CDNs rather than GitHub Actions cache shouldn't be an issue for most repositories
- self-hosted runners provided by IPDX come with their own Go modules cache located close to the runners so we don't need to use the GitHub Actions cache there