### PR TITLE
fix: do not persist credentials after checkout in js release step

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -239,6 +239,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*


### PR DESCRIPTION
If we don't set this to not persist credentials, semantic release will not set the github token and releases fail in repos that have branch protection turned on.

Refs:
- https://github.com/semantic-release/git/issues/196#issuecomment-1826189788
- https://github.com/semantic-release/git/issues/196#issuecomment-601310576