### PR TITLE
feat: allow overriding docker registry in js releases

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: ${{ format('["{0}"]', github.event.repository.default_branch) }}
+      docker-registry:
+        required: false
+        type: string
+        default: 'ghcr.io'
     secrets:
       DOCKER_TOKEN:
         required: false
@@ -248,6 +252,7 @@ jobs:
         with:
           docker-token: ${{ secrets.DOCKER_TOKEN }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-registry: ${{ inputs.docker-registry }}
       - run: npm run --if-present release
         env:
           GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}


### PR DESCRIPTION
When logging in to a docker registry, allow specifying which registry to log in to.

This part of the action was originally added to publish js-ipfs containers but that project is long retired so defaulting to the github container registry instead of docker hub should be fine.