### PR TITLE
release v1.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.0.15] - 2024-11-28
+### Changed
+- updated references to aegir master to main after the default branch rename
+
 ## [1.0.14] - 2024-10-23
 ### Changed
 - simplified the default `go-version` input calculation in the go-check workflow


### PR DESCRIPTION
This release contains an update to the JS reusable workflow, it renames references to aegir master to main as the default branch in aegir has been renamed.