### PR TITLE
feat: add spell-check to check job

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -28,20 +28,31 @@ defaults:
 
 jobs:
 
-  check:
+  build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-    - uses: ipfs/aegir/actions/cache-node-modules@main
-    - run: npm run --if-present lint
-    - run: npm run --if-present dep-check
-    - run: npm run --if-present doc-check
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - uses: ipfs/aegir/actions/cache-node-modules@main
+
+  check:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - run: npm run --if-present lint
+      - run: npm run --if-present dep-check
+      - run: npm run --if-present doc-check
+      - run: npm run --if-present spell-check
 
   test-node:
-    needs: check
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -63,7 +74,7 @@ jobs:
           fail_ci_if_error: false
 
   test-chrome:
-    needs: check
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +91,7 @@ jobs:
           fail_ci_if_error: false
 
   test-chrome-webworker:
-    needs: check
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +108,7 @@ jobs:
           fail_ci_if_error: false
 
   test-firefox:
-    needs: check
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +125,7 @@ jobs:
           fail_ci_if_error: false
 
   test-firefox-webworker:
-    needs: check
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -131,7 +142,7 @@ jobs:
           fail_ci_if_error: false
 
   test-webkit:
-    needs: check
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -154,7 +165,7 @@ jobs:
           fail_ci_if_error: false
 
   test-webkit-webworker:
-    needs: check
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -177,7 +188,7 @@ jobs:
           fail_ci_if_error: false
 
   test-electron-main:
-    needs: check
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -194,7 +205,7 @@ jobs:
           fail_ci_if_error: false
 
   test-electron-renderer:
-    needs: check
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds an optional `spell-check` step to the `check` job.

Adds a `build` job that ensures the `node_modules` cache is present for other steps.

Makes all `test-*` jobs depend on `build` instead of `check` so they can run in parallel.