### PR TITLE
release v1.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [1.0.23] - 2025-06-10
 ### Fixed
 - added a repository checkout to fix the gh cli usage in the tagpush workflow
 - disabled the safe directory locking in the go-test workflow on Windows runners


### PR DESCRIPTION
This release fixes codecov uploads on Windows after the hosted runners started running on the C: drive by default. It also fixes the tag push workflow.