### PR TITLE
feat: skip 32 bit tests in go-test by default

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -117,7 +117,8 @@ jobs:
       - name: Run tests (32 bit)
         # can't run 32 bit tests on OSX.
         if: matrix.os != 'macos' &&
-          fromJSON(steps.config.outputs.json).skip32bit != true &&
+          contains(steps.config.outputs.json, '"skip32bit"') &&
+          fromJSON(steps.config.outputs.json).skip32bit == false &&
           contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
         uses: protocol/multiple-go-modules@v1.4
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- skip 32-bit tests in the `go-test` workflow by default (they can still be enabled by setting `skip32bit` to `false` in the `go-test-config.json`)
 
 ## [1.0.27] - 2025-06-15
 ### Fixed


### PR DESCRIPTION
Resolves https://github.com/ipdxco/unified-github-workflows/issues/118