### PR TITLE
fix: emit 0/1 for CGO_ENABLED so the cgo config takes effect

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -162,7 +162,9 @@ jobs:
         uses: protocol/multiple-go-modules@v1.4
         env:
           GOFLAGS: ${{ format('{0} {1}', env.GOTESTFLAGS, env.GOFLAGS) }}
-          CGO_ENABLED: ${{ toJSON(fromJSON(steps.config.outputs.json).cgo) != 'false' }}
+          # go only recognizes CGO_ENABLED values of 0 and 1; anything else
+          # (e.g. true/false) is ignored in favor of the platform default
+          CGO_ENABLED: ${{ toJSON(fromJSON(steps.config.outputs.json).cgo) != 'false' && '1' || '0' }}
         with:
           run: go test ./...
       - name: Run tests (32 bit)
@@ -175,7 +177,7 @@ jobs:
         env:
           GOARCH: 386
           GOFLAGS: ${{ format('{0} {1}', env.GO386FLAGS, env.GOFLAGS) }}
-          CGO_ENABLED: ${{ toJSON(fromJSON(steps.config.outputs.json).cgo) != 'false' }}
+          CGO_ENABLED: ${{ toJSON(fromJSON(steps.config.outputs.json).cgo) != 'false' && '1' || '0' }}
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
@@ -188,7 +190,9 @@ jobs:
         uses: protocol/multiple-go-modules@v1.4
         env:
           GOFLAGS: ${{ format('{0} {1}', env.GORACEFLAGS, env.GOFLAGS) }}
-          CGO_ENABLED: ${{ toJSON(fromJSON(steps.config.outputs.json).cgo) != 'false' }}
+          # the race detector requires cgo, even when the repo disables it
+          # for the regular test runs
+          CGO_ENABLED: '1'
         with:
           run: go test -race ./...
       - name: Collect coverage files

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ If you want to disable cgo, you can do so by setting `cgo` to `false` in `.githu
   "cgo": false
 }
 ```
+This applies to the regular and 32-bit test runs. The race detector run always keeps cgo enabled because `go test -race` requires it; set `skipRace` to `true` if your module cannot build with cgo at all.
 
 ### Workflow Modification
 


### PR DESCRIPTION
The `cgo` option in `go-test-config.json` has never worked. The workflow renders it as `CGO_ENABLED=true` or `CGO_ENABLED=false`, and Go only recognizes `0` and `1`; any other value falls back to the platform default, which is `1` on every hosted runner. Repos that set `"cgo": false` have been testing with cgo enabled all along. You can see it in any such repo's job log: the test step env shows `CGO_ENABLED: false` while `go env` reports `CGO_ENABLED='1'`.

This PR makes the regular and 32-bit test steps emit `1` or `0`. The race detector step is pinned to `1`, since `go test -race` requires cgo; a real `0` there would break the race run for every repo that sets `"cgo": false` without `skipRace`. The README documents the race caveat and points at `skipRace` for modules that cannot build with cgo at all.

BREAKING CHANGE: repos with `"cgo": false` will run cgo-free tests for the first time, and some will start failing where a dependency needs cgo on a given OS (for example, `elastic/gosigar` compiles without cgo on Linux but requires it on macOS). Those repos should either fix the build or drop the option.